### PR TITLE
RsuGrants can accept a quantity of RSUs, not just their total value.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ gnuplot parameters in the generated gnuplot file.
                 bonus = 50000,
                 state = "CA",
                 color = "red",
-                grants = RsuGrant(total = 100000),
+                grants = RsuGrant(total_by_value = 100000),
             ),
 
             Offer(
@@ -80,7 +80,7 @@ gnuplot parameters in the generated gnuplot file.
                 bonus = 10000,
                 state = "WA",
                 color = "purple",
-                grants = RsuGrant(total = 250000,
+                grants = RsuGrant(total_by_value = 250000,
                                   vesting = (0.05, 0.15, 0.40, 0.40))),
 
         ),

--- a/demo.py
+++ b/demo.py
@@ -16,7 +16,7 @@ make_offer_comparison(
             bonus = 50000,
             state = "CA",
             color = "red",
-            grants = RsuGrant(total = 100000),
+            grants = RsuGrant(total_by_value = 100000),
         ),
 
         Offer(
@@ -25,7 +25,7 @@ make_offer_comparison(
             bonus = 10000,
             state = "WA",
             color = "purple",
-            grants = RsuGrant(total = 250000,
+            grants = RsuGrant(total_by_value = 250000,
                               vesting = (0.05, 0.15, 0.40, 0.40))),
 
     ),

--- a/valleyjudge.py
+++ b/valleyjudge.py
@@ -296,9 +296,15 @@ class RsuGrant(object):
                  vesting = (0.25, 0.25, 0.25, 0.25)):
         """Create an equity grant description.
 
-        TOTAL is the total size, in dollars, of the grant.  START is
-        the date on which it starts; if None, the grant clock starts
-        on the company start date.  VESTING_DATES is a sequence of
+        TOTAL_BY_VALUE is the total size, in dollars, of the grant.  
+        TOTAL_BY_QUANTITY is the total size, in number of RSUs, of the grant.
+        Only one (TOTAL_BY_VALUE or TOTAL_BY_QUANTITY) should be provided.
+        STOCK_NAME is the stock ticker symbol for the company ("AMZN", "GOOG",
+        etc). This only needs to be provided if using TOTAL_BY_QUANTITY, so the
+        current stock price can be looked up.
+        
+        START is the date on which the grant starts; if None, the grant clock
+        starts on the company start date.  VESTING_DATES is a sequence of
         (MONTH, DAY) pairs on which equity grants vest --- a grant
         that vests quarterly will have a four-element
         VESTING_DATES sequence.

--- a/valleyjudge.py
+++ b/valleyjudge.py
@@ -316,12 +316,16 @@ class RsuGrant(object):
 
         """
         if total_by_value is not None and total_by_quantity is not None:
-            raise ValueError("Either provide totals by value or by quantity, not both")
+            raise ValueError("Either provide totals by value or by quantity, "
+                             "not both")
         if not math.isclose(sum(vesting), 1.0, rel_tol=1e-5):
-            raise ValueError("Vesting fractions do not sum to 1: %1.5f" % sum(vesting))
+            raise ValueError("Vesting fractions do not sum to 1: %1.5f"
+                             % sum(vesting))
         if total_by_quantity is not None:
             self.stock_name = typecheck(stock_name, str)
-        self.total = typecheck(total_by_value, numbers.Real) if total_by_value is not None else self.get_stock_value(total_by_quantity, Stock(stock_name)) 
+        self.total = typecheck(total_by_value, numbers.Real) if total_by_value \
+                     is not None else self.get_stock_value(
+                         total_by_quantity, Stock(stock_name)) 
         self.start = typecheck(start, (date, timedelta, type(None)))
         self.vesting_dates = typecheck(vesting_dates, seq_of(pair_of(int)))
         self.vesting = typecheck(vesting, seq_of(numbers.Real))

--- a/valleyjudge.py
+++ b/valleyjudge.py
@@ -11,7 +11,12 @@ from collections import defaultdict, Iterable, namedtuple
 from datetime import date, datetime, timedelta
 from itertools import accumulate
 from os.path import basename
-from rtstock.stock import Stock
+try:
+    from rtstock.stock import Stock
+except ImportError:
+    raise ImportError('The realtime-stock package is required. You can find out '
+                      'how to install it here: '
+                      'https://pypi.python.org/pypi/realtime-stock')
 from types import new_class
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
Changed RsuGrant from accepting a total to accepting either a total by value ($10,000) or a total by quantity (88 RSUs) and a stock ticker symbol ("AAPL").  In the latter case, "total by value" is calculated using the quantity and the latest stock price.

Also organized imports and moved error checking ahead of value assignment because there's no 
need to assign values if we're going to throw an error anyway.